### PR TITLE
Add payload to events and style to x/y axis elements

### DIFF
--- a/src/Bar.re
+++ b/src/Bar.re
@@ -29,14 +29,36 @@ external make:
     ~maxBarSize: int=?,
     ~minPointSize: int=?,
     ~name: string=?,
-    ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseDown: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseLeave: (Js.t({..}), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseMove: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseOut: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseOver: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseUp: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
+    ~onClick: (Js.t({.. "payload": 'dataItem}), int, ReactEvent.Mouse.t) =>
+              unit
+                =?,
+    ~onMouseDown: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseEnter: (
+                     Js.t({.. "payload": 'dataItem}),
+                     int,
+                     ReactEvent.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseLeave: (
+                     Js.t({.. "payload": 'dataItem}),
+                     int,
+                     ReactEvent.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseMove: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseOut: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) => unit
+                   =?,
+    ~onMouseOver: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseUp: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) => unit
+                  =?,
     ~radius: array(int)=?,
     ~shape: 'shape=?,
     ~stackId: string=?,

--- a/src/Pie.re
+++ b/src/Pie.re
@@ -31,14 +31,42 @@ external make:
     ~legendType: legendType=?,
     ~minAngle: int=?,
     ~nameKey: string=?,
-    ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseDown: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseLeave: (Js.t({..}), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseMove: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseOut: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseOver: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~onMouseUp: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
+    // Pulled from:
+    // https://github.com/recharts/recharts/blob/7fb227dae542c3d3093506e6d80a2c2c366f9a26/src/polar/Pie.tsx#L107-L109
+    ~onClick: (
+                Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                int,
+                ReactEvent.Mouse.t
+              ) =>
+              unit
+                =?,
+    ~onMouseDown: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseEnter: (
+                     Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                     int,
+                     ReactEvent.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseLeave: (
+                     Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                     int,
+                     ReactEvent.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseMove: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseOut: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) => unit
+                   =?,
+    ~onMouseOver: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseUp: (Js.t({.. "payload": 'dataItem}), ReactEvent.Mouse.t) => unit
+                  =?,
     ~outerRadius: PxOrPrc.t=?,
     ~paddingAngle: int=?,
     ~startAngle: int=?,

--- a/src/XAxis.re
+++ b/src/XAxis.re
@@ -31,6 +31,7 @@ external make:
     ~padding: paddingHorizontal=?,
     ~reversed: bool=?,
     ~scale: scale=?,
+    ~style: ReactDOMStyle.t=?,
     ~tick: 'tick=?,
     ~tickCount: int=?,
     ~tickFormatter: 'tickFormatter=?,
@@ -45,4 +46,5 @@ external make:
   React.element =
   "XAxis";
 
-let makeProps = (~interval=?) => makeProps(~interval=?interval->AxisInterval.encodeOpt);
+let makeProps = (~interval=?) =>
+  makeProps(~interval=?interval->AxisInterval.encodeOpt);

--- a/src/YAxis.re
+++ b/src/YAxis.re
@@ -31,6 +31,7 @@ external make:
     ~padding: paddingVertical=?,
     ~reversed: bool=?,
     ~scale: scale=?,
+    ~style: ReactDOMStyle.t=?,
     ~tick: 'tick=?,
     ~tickCount: int=?,
     ~tickFormatter: 'tickFormatter=?,
@@ -45,4 +46,5 @@ external make:
   React.element =
   "YAxis";
 
-let makeProps = (~interval=?) => makeProps(~interval=?interval->AxisInterval.encodeOpt);
+let makeProps = (~interval=?) =>
+  makeProps(~interval=?interval->AxisInterval.encodeOpt);


### PR DESCRIPTION
This PR has a few small updates to the bindings:

- Adds the `"payload": `dataItem` to the events
- Adds the `style: ReactDOMStyle.t` to the XAxis and YAxis elements