### PR TITLE
Add data prop to Line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 4.0.4 (2024-07-26)
+
+- add `data` to `Line`
+
 ## 4.0.3 (2024-06-04)
 
 - add `filterNull` to `Tooltip`

--- a/src/Line.re
+++ b/src/Line.re
@@ -19,6 +19,7 @@ external make:
     ~className: string=?,
     ~connectNulls: bool=?,
     ~hide: bool=?,
+    ~data: array('data)=?,
     ~dataKey: 'dataKey,
     ~dot: 'dot=?,
     ~id: string=?,


### PR DESCRIPTION
This PR adds the `data` prop to Line.

Even though it is not in the API, it is supported and required if we want to plot different lines using different data sets. I also see that it was added to `Bar` a couple of years ago, and was probably mistakenly omitted from `Line`.