### PR TITLE
Added bindings for style prop to each chart type.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 4.0.5 (2024-10-01)
+
+- add `style` to `AreaChart`
+- add `style` to `BarChart`
+- add `style` to `ComposedChart`
+- add `style` to `LineChart`
+- add `style` to `PieChart`
+- add `style` to `ScatterChart`
+
 ## 4.0.4 (2024-07-26)
 
 - add `data` to `Line`

--- a/src/AreaChart.re
+++ b/src/AreaChart.re
@@ -10,6 +10,7 @@ external make:
     ~height: int=?,
     ~layout: layout=?,
     ~margin: margin=?,
+    ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/BarChart.re
+++ b/src/BarChart.re
@@ -13,6 +13,7 @@ external make:
     ~layout: layout=?,
     ~margin: margin=?,
     ~maxBarSize: int=?,
+    ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/ComposedChart.re
+++ b/src/ComposedChart.re
@@ -12,6 +12,7 @@ external make:
     ~height: int=?,
     ~layout: layout=?,
     ~margin: margin=?,
+    ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/LineChart.re
+++ b/src/LineChart.re
@@ -9,6 +9,7 @@ external make:
     ~height: int=?,
     ~layout: layout=?,
     ~margin: margin=?,
+    ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/PieChart.re
+++ b/src/PieChart.re
@@ -7,6 +7,7 @@ external make:
     ~className: string=?,
     ~height: int=?,
     ~margin: margin=?,
+    ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,

--- a/src/ScatterChart.re
+++ b/src/ScatterChart.re
@@ -7,6 +7,7 @@ external make:
     ~className: string=?,
     ~height: int=?,
     ~margin: margin=?,
+    ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,


### PR DESCRIPTION
Adding style prop will help with customizability on ahrefs. For example, it will help change the mouse cursor types to display interactivity of the certain charts.