### PR TITLE
Adding strokeOpacity property to Line module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 4.0.6 (2024-10-19)
+
+- add `strokeOpacity` to `Line`
+
 ## 4.0.5 (2024-10-01)
 
 - add `style` to `AreaChart`

--- a/src/Line.re
+++ b/src/Line.re
@@ -39,6 +39,7 @@ external make:
     ~points: array(Js.t({..}))=?,
     ~stroke: string=?,
     ~strokeWidth: int=?,
+    ~strokeOpacity: option(float)=?,
     ~strokeDasharray: string=?,
     ~unit: string=?,
     ~xAxisId: string=?,


### PR DESCRIPTION
We need to have strokeOpacity property on lines available for some more advanced customization of line charts.