### PR TITLE
Remove types from Utils that can be represented by [@mel.unwrap]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Unpublished
 
 - *[breaking]* improve bindings for XYZ axes, Treemap, Pie and Cell components [#59](https://github.com/ahrefs/melange-recharts/pull/59)
+- *[breaking]* remove `TooltipCursor` module [#60](https://github.com/ahrefs/melange-recharts/pull/60)
 
 ## 4.0.7 (2024-11-23)
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,6 @@ module PxOrPrc = {
     | Prc(float);
   ...
 };
-
-module StrOrNode = {
-  ...
-  type arg =
-    | Str(string)
-    | Node(ReasonReact.reactElement);
-  ...
-};
 ```
 
 you will use it like this:
@@ -72,15 +64,9 @@ you will use it like this:
 ```reason
 <XAxis
   interval=PreserveStart
-  label=Str("text")
 />
 <XAxis
   interval=Num(12)
-  label=Node(
-    <span>
-      (ReasonReact.stringToElement("text"))
-    </span>
-  )
 />
 ```
 

--- a/src/Tooltip.re
+++ b/src/Tooltip.re
@@ -1,6 +1,4 @@
 // http://recharts.org/en-US/api/Tooltip
-open Utils;
-
 [@mel.module "recharts"] [@react.component]
 external make:
   (
@@ -20,7 +18,20 @@ external make:
     ~className: string=?,
     ~content: 'content=?,
     ~position: Js.t({..})=?,
-    ~cursor: TooltipCursor.t=?,
+    ~cursor:
+      [@mel.unwrap] [
+        | `Bool(bool)
+        | `Obj(
+            Js.t({
+              .
+              "fill": option(string),
+              "stroke": option(string),
+              "strokeWidth": option(int),
+            }),
+          )
+        | `Element(React.element)
+      ]
+        =?,
     ~filterNull: bool=?,
     ~formatter: 'formatter=?,
     ~isAnimationActive: bool=?,
@@ -37,6 +48,3 @@ external make:
   ) =>
   React.element =
   "Tooltip";
-
-let makeProps = (~cursor=?) =>
-  makeProps(~cursor=?cursor->TooltipCursor.encodeOpt);

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -131,27 +131,3 @@ module PxOrPrc = {
     | Prc(v) => Obj.magic(Js.Float.toString(v) ++ "%");
   let encodeOpt = Option.map(encode);
 };
-
-module TooltipCursor = {
-  [@deriving jsProperties]
-  type config = {
-    [@mel.optional]
-    fill: option(string),
-    [@mel.optional]
-    stroke: option(string),
-    [@mel.optional]
-    strokeWidth: option(int),
-  };
-
-  type t;
-  type arg =
-    | Bool(bool)
-    | Config(config)
-    | Component(React.element);
-  let encode: arg => t =
-    fun
-    | Bool(v) => Obj.magic(v)
-    | Config(v) => Obj.magic(v)
-    | Component(v) => Obj.magic(v);
-  let encodeOpt = Option.map(encode);
-};

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -132,18 +132,6 @@ module PxOrPrc = {
   let encodeOpt = Option.map(encode);
 };
 
-module StrOrNode = {
-  type t;
-  type arg =
-    | Str(string)
-    | Node(React.element);
-  let encode: arg => t =
-    fun
-    | Str(v) => Obj.magic(v)
-    | Node(v) => Obj.magic(v);
-  let encodeOpt = Option.map(encode);
-};
-
 module TooltipCursor = {
   [@deriving jsProperties]
   type config = {


### PR DESCRIPTION
This is implementing @liubko's suggestion in [this comment](https://github.com/ahrefs/melange-recharts/pull/59#discussion_r1861863008).

- Removes `TooltipCursor` module
- Removes `StrOrNode` module

Both of those can be represented using `[@mel.unwrap]` which is a 0-cost binding solution.