### PR TITLE
dep: update recharts to 2.14.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-## Unpublished
+## 5.0.1
+
+- update `recharts` to `2.14.1`
+
+## 5.0.0
 
 - *[breaking]* improve bindings for XYZ axes, Treemap, Pie and Cell components [#59](https://github.com/ahrefs/melange-recharts/pull/59)
 - *[breaking]* remove `TooltipCursor` module [#60](https://github.com/ahrefs/melange-recharts/pull/60)

--- a/melange-recharts.opam
+++ b/melange-recharts.opam
@@ -36,5 +36,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ahrefs/melange-recharts.git"
 depexts: [
-  ["recharts"] {npm-version = "^2.1.12"}
+  ["recharts"] {npm-version = "^2.14.1"}
 ]


### PR DESCRIPTION
This PR fixes up `CHANGES.md` and updates `recharts` to `v2.14.1` which hopefully fixes  this [high severity vulnerability](https://www.npmjs.com/advisories/1088594) 