### PR TITLE
Fix tooltip cursor type

### DIFF
--- a/example/Example.re
+++ b/example/Example.re
@@ -2,9 +2,9 @@ open Recharts;
 
 [@react.component]
 let make = (~data) =>
-  <ResponsiveContainer height=(Px(200.)) width=(Px(300.))>
+  <ResponsiveContainer height={Px(200.)} width={Px(300.)}>
     <BarChart
-      barCategoryGap=(Px(1.))
+      barCategoryGap={Px(1.)}
       margin={"top": 0, "right": 0, "bottom": 0, "left": 0}
       data>
       <Bar name="Some bar" dataKey="pv" fill="#2078b4" stackId="a" />

--- a/src/Area.re
+++ b/src/Area.re
@@ -8,15 +8,14 @@ external make:
     ~activeDot: 'activeDot=?,
     ~animationBegin: int=?,
     ~animationDuration: int=?,
-    ~animationEasing:
-      [@mel.string] [
-        | `ease
-        | [@mel.as "ease-in"] `easeIn
-        | [@mel.as "ease-out"] `easeOut
-        | [@mel.as "ease-in-out"] `easeInOut
-        | `linear
-      ]
-        =?,
+    ~animationEasing: [@mel.string] [
+                        | `ease
+                        | [@mel.as "ease-in"] `easeIn
+                        | [@mel.as "ease-out"] `easeOut
+                        | [@mel.as "ease-in-out"] `easeInOut
+                        | `linear
+                      ]
+                        =?,
     ~baseLine: 'baseLine=?,
     ~connectNulls: bool=?,
     ~hide: bool=?,
@@ -33,8 +32,7 @@ external make:
     ~name: string=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/AreaChart.re
+++ b/src/AreaChart.re
@@ -14,8 +14,7 @@ external make:
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~stackOffset: stackOffset=?,

--- a/src/Bar.re
+++ b/src/Bar.re
@@ -6,15 +6,14 @@ external make:
   (
     ~animationBegin: int=?,
     ~animationDuration: int=?,
-    ~animationEasing:
-      [@mel.string] [
-        | `ease
-        | [@mel.as "ease-in"] `easeIn
-        | [@mel.as "ease-out"] `easeOut
-        | [@mel.as "ease-in-out"] `easeInOut
-        | `linear
-      ]
-        =?,
+    ~animationEasing: [@mel.string] [
+                        | `ease
+                        | [@mel.as "ease-in"] `easeIn
+                        | [@mel.as "ease-out"] `easeOut
+                        | [@mel.as "ease-in-out"] `easeInOut
+                        | `linear
+                      ]
+                        =?,
     ~background: 'background=?,
     ~barSize: int=?,
     ~className: string=?,
@@ -30,22 +29,37 @@ external make:
     ~maxBarSize: int=?,
     ~minPointSize: int=?,
     ~name: string=?,
-    ~onClick:
-      (Js.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) => unit=?,
-    ~onMouseDown:
-      (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) => unit=?,
-    ~onMouseLeave:
-      (Js.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) => unit=?,
-    ~onMouseMove:
-      (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) => unit=?,
-    ~onMouseOut:
-      (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) => unit=?,
-    ~onMouseOver:
-      (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) => unit=?,
-    ~onMouseUp:
-      (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) => unit=?,
+    ~onClick: (Js.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) =>
+              unit
+                =?,
+    ~onMouseDown: (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseEnter: (
+                     Js.t({.. "payload": 'dataItem}),
+                     int,
+                     React.Event.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseLeave: (
+                     Js.t({.. "payload": 'dataItem}),
+                     int,
+                     React.Event.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseMove: (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseOut: (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) =>
+                 unit
+                   =?,
+    ~onMouseOver: (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) =>
+                  unit
+                    =?,
+    ~onMouseUp: (Js.t({.. "payload": 'dataItem}), React.Event.Mouse.t) => unit
+                  =?,
     ~radius: array(int)=?,
     ~shape: 'shape=?,
     ~stackId: string=?,

--- a/src/BarChart.re
+++ b/src/BarChart.re
@@ -17,8 +17,7 @@ external make:
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~reverseStackOrder: bool=?,

--- a/src/CartesianAxis.re
+++ b/src/CartesianAxis.re
@@ -24,4 +24,5 @@ external make:
   React.element =
   "CartesianAxis";
 
-let makeProps = (~interval=?) => makeProps(~interval=?interval->AxisInterval.encodeOpt);
+let makeProps = (~interval=?) =>
+  makeProps(~interval=?interval->AxisInterval.encodeOpt);

--- a/src/ComposedChart.re
+++ b/src/ComposedChart.re
@@ -16,8 +16,7 @@ external make:
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~reverseStackOrder: bool=?,

--- a/src/Dot.re
+++ b/src/Dot.re
@@ -9,8 +9,7 @@ external make:
     ~fill: string,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/Legend.re
+++ b/src/Legend.re
@@ -4,51 +4,37 @@ open Utils;
 [@mel.module "recharts"] [@react.component]
 external make:
   (
-    ~align:
-      [
-        | `left
-        | `center
-        | `right
-      ]
-        =?,
+    ~align: [ | `left | `center | `right]=?,
     ~chartHeight: int=?,
     ~chartWidth: int=?,
     ~content: 'content=?,
     ~className: string=?,
     ~height: int=?,
     ~iconSize: int=?,
-    ~iconType:
-      [
-        | `line
-        | `square
-        | `rect
-        | `circle
-        | `cross
-        | `diamond
-        | `star
-        | `triangle
-        | `wye
-      ]
-        =?,
+    ~iconType: [
+                 | `line
+                 | `square
+                 | `rect
+                 | `circle
+                 | `cross
+                 | `diamond
+                 | `star
+                 | `triangle
+                 | `wye
+               ]
+                 =?,
     ~layout: layout=?,
     ~margin: margin=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOver: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~payload: array(Js.t({..}))=?,
-    ~verticalAlign:
-      [
-        | `top
-        | `middle
-        | `bottom
-      ]
-        =?,
+    ~verticalAlign: [ | `top | `middle | `bottom]=?,
     ~width: int=?,
     ~wrapperStyle: Js.t({..})=?
   ) =>

--- a/src/Line.re
+++ b/src/Line.re
@@ -8,15 +8,14 @@ external make:
     ~activeDot: 'activeDot=?,
     ~animationBegin: int=?,
     ~animationDuration: int=?,
-    ~animationEasing:
-      [@mel.string] [
-        | `ease
-        | [@mel.as "ease-in"] `easeIn
-        | [@mel.as "ease-out"] `easeOut
-        | [@mel.as "ease-in-out"] `easeInOut
-        | `linear
-      ]
-        =?,
+    ~animationEasing: [@mel.string] [
+                        | `ease
+                        | [@mel.as "ease-in"] `easeIn
+                        | [@mel.as "ease-out"] `easeOut
+                        | [@mel.as "ease-in-out"] `easeInOut
+                        | `linear
+                      ]
+                        =?,
     ~className: string=?,
     ~connectNulls: bool=?,
     ~hide: bool=?,
@@ -31,8 +30,7 @@ external make:
     ~name: string=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/LineChart.re
+++ b/src/LineChart.re
@@ -13,8 +13,7 @@ external make:
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~syncId: string=?,

--- a/src/Pie.re
+++ b/src/Pie.re
@@ -8,15 +8,14 @@ external make:
     ~activeShape: 'activeShape=?,
     ~animationBegin: int=?,
     ~animationDuration: int=?,
-    ~animationEasing:
-      [@mel.string] [
-        | `ease
-        | [@mel.as "ease-in"] `easeIn
-        | [@mel.as "ease-out"] `easeOut
-        | [@mel.as "ease-in-out"] `easeInOut
-        | `linear
-      ]
-        =?,
+    ~animationEasing: [@mel.string] [
+                        | `ease
+                        | [@mel.as "ease-in"] `easeIn
+                        | [@mel.as "ease-out"] `easeOut
+                        | [@mel.as "ease-in-out"] `easeInOut
+                        | `linear
+                      ]
+                        =?,
     ~className: string=?,
     ~cx: PxOrPrc.t=?,
     ~cy: PxOrPrc.t=?,
@@ -34,53 +33,57 @@ external make:
     ~nameKey: string=?,
     // Pulled from:
     // https://github.com/recharts/recharts/blob/7fb227dae542c3d3093506e6d80a2c2c366f9a26/src/polar/Pie.tsx#L107-L109
-    ~onClick:
-      (Js.Nullable.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) =>
-      unit
-        =?,
-    ~onMouseEnter:
-      (Js.Nullable.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) =>
-      unit
-        =?,
-    ~onMouseLeave:
-      (Js.Nullable.t({.. "payload": 'dataItem}), int, React.Event.Mouse.t) =>
-      unit
-        =?,
-    ~onMouseDown:
-      (
-        Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
-        React.Event.Mouse.t
-      ) =>
-      unit
-        =?,
-    ~onMouseMove:
-      (
-        Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
-        React.Event.Mouse.t
-      ) =>
-      unit
-        =?,
-    ~onMouseOut:
-      (
-        Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
-        React.Event.Mouse.t
-      ) =>
-      unit
-        =?,
-    ~onMouseOver:
-      (
-        Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
-        React.Event.Mouse.t
-      ) =>
-      unit
-        =?,
-    ~onMouseUp:
-      (
-        Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
-        React.Event.Mouse.t
-      ) =>
-      unit
-        =?,
+    ~onClick: (
+                Js.Nullable.t({.. "payload": 'dataItem}),
+                int,
+                React.Event.Mouse.t
+              ) =>
+              unit
+                =?,
+    ~onMouseEnter: (
+                     Js.Nullable.t({.. "payload": 'dataItem}),
+                     int,
+                     React.Event.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseLeave: (
+                     Js.Nullable.t({.. "payload": 'dataItem}),
+                     int,
+                     React.Event.Mouse.t
+                   ) =>
+                   unit
+                     =?,
+    ~onMouseDown: (
+                    Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                    React.Event.Mouse.t
+                  ) =>
+                  unit
+                    =?,
+    ~onMouseMove: (
+                    Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                    React.Event.Mouse.t
+                  ) =>
+                  unit
+                    =?,
+    ~onMouseOut: (
+                   Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                   React.Event.Mouse.t
+                 ) =>
+                 unit
+                   =?,
+    ~onMouseOver: (
+                    Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                    React.Event.Mouse.t
+                  ) =>
+                  unit
+                    =?,
+    ~onMouseUp: (
+                  Js.Nullable.t(Js.t({.. "payload": 'dataItem})),
+                  React.Event.Mouse.t
+                ) =>
+                unit
+                  =?,
     ~outerRadius: PxOrPrc.t=?,
     ~paddingAngle: int=?,
     ~startAngle: int=?,

--- a/src/PieChart.re
+++ b/src/PieChart.re
@@ -9,8 +9,7 @@ external make:
     ~margin: margin=?,
     ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~width: int=?,
     ~children: React.element

--- a/src/ReferenceArea.re
+++ b/src/ReferenceArea.re
@@ -11,8 +11,7 @@ external make:
     ~fillOpacity: float=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/ReferenceDot.re
+++ b/src/ReferenceDot.re
@@ -10,8 +10,7 @@ external make:
     ~label: 'label=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/ReferenceLine.re
+++ b/src/ReferenceLine.re
@@ -10,8 +10,7 @@ external make:
     ~label: 'label=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/ResponsiveContainer.re
+++ b/src/ResponsiveContainer.re
@@ -17,4 +17,7 @@ external make:
   "ResponsiveContainer";
 
 let makeProps = (~height=?, ~width=?) =>
-  makeProps(~height=?height->PxOrPrc.encodeOpt, ~width=?width->PxOrPrc.encodeOpt);
+  makeProps(
+    ~height=?height->PxOrPrc.encodeOpt,
+    ~width=?width->PxOrPrc.encodeOpt,
+  );

--- a/src/Scatter.re
+++ b/src/Scatter.re
@@ -22,18 +22,16 @@ external make:
     ~isAnimationActive: bool=?,
     ~animationBegin: int=?,
     ~animationDuration: int=?,
-    ~animationEasing:
-      [@mel.string] [
-        | `ease
-        | [@mel.as "ease-in"] `easeIn
-        | [@mel.as "ease-out"] `easeOut
-        | [@mel.as "ease-in-out"] `easeInOut
-        | `linear
-      ]
-        =?,
+    ~animationEasing: [@mel.string] [
+                        | `ease
+                        | [@mel.as "ease-in"] `easeIn
+                        | [@mel.as "ease-out"] `easeOut
+                        | [@mel.as "ease-in-out"] `easeInOut
+                        | `linear
+                      ]
+                        =?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/ScatterChart.re
+++ b/src/ScatterChart.re
@@ -9,8 +9,7 @@ external make:
     ~margin: margin=?,
     ~style: ReactDOM.Style.t=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,

--- a/src/Tooltip.re
+++ b/src/Tooltip.re
@@ -6,32 +6,23 @@ external make:
     ~allowEscapeViewBox: Js.t({..})=?,
     ~animationBegin: int=?,
     ~animationDuration: int=?,
-    ~animationEasing:
-      [@mel.string] [
-        | `ease
-        | [@mel.as "ease-in"] `easeIn
-        | [@mel.as "ease-out"] `easeOut
-        | [@mel.as "ease-in-out"] `easeInOut
-        | `linear
-      ]
-        =?,
+    ~animationEasing: [@mel.string] [
+                        | `ease
+                        | [@mel.as "ease-in"] `easeIn
+                        | [@mel.as "ease-out"] `easeOut
+                        | [@mel.as "ease-in-out"] `easeInOut
+                        | `linear
+                      ]
+                        =?,
     ~className: string=?,
     ~content: 'content=?,
     ~position: Js.t({..})=?,
-    ~cursor:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(
-            Js.t({
-              .
-              "fill": option(string),
-              "stroke": option(string),
-              "strokeWidth": option(int),
-            }),
-          )
-        | `Element(React.element)
-      ]
-        =?,
+    ~cursor: [@mel.unwrap] [
+               | `Bool(bool)
+               | `Obj(Js.t({..}))
+               | `Element(React.element)
+             ]
+               =?,
     ~filterNull: bool=?,
     ~formatter: 'formatter=?,
     ~isAnimationActive: bool=?,

--- a/src/Treemap.re
+++ b/src/Treemap.re
@@ -18,8 +18,7 @@ external make:
     ~onClick: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseEnter: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~children: React.element=?

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -44,23 +44,11 @@ type scale = [
   | `threshold
 ];
 
-type axisType = [
-  | `number
-  | `category
-];
+type axisType = [ | `number | `category];
 
-type layout = [
-  | `horizontal
-  | `vertical
-];
+type layout = [ | `horizontal | `vertical];
 
-type stackOffset = [
-  | `expand
-  | `none
-  | `wiggle
-  | `silhouette
-  | `sign
-];
+type stackOffset = [ | `expand | `none | `wiggle | `silhouette | `sign];
 
 type margin = {
   .

--- a/src/XAxis.re
+++ b/src/XAxis.re
@@ -8,91 +8,61 @@ external make:
     ~allowDataOverflow: bool=?,
     ~allowDecimals: bool=?,
     ~allowDuplicatedCategory: bool=?,
-    ~axisLine:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~axisLine: [@mel.unwrap] [ | `Bool(bool) | `Obj(Js.t({..}))]=?,
     ~className: string=?,
-    ~dataKey:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Fn('dataObj => 'data)
-      ]
-        =?,
+    ~dataKey: [@mel.unwrap] [
+                | `Str(string)
+                | `Int(int)
+                | `Fn('dataObj => 'data)
+              ]
+                =?,
     ~domain: array('domain)=?,
     ~height: int=?,
     ~hide: bool=?,
     ~interval: AxisInterval.t=?,
-    ~label:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Float(float)
-        | `Element(React.element)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~label: [@mel.unwrap] [
+              | `Str(string)
+              | `Int(int)
+              | `Float(float)
+              | `Element(React.element)
+              | `Obj(Js.t({..}))
+            ]
+              =?,
     ~minTickGap: int=?,
     ~mirror: bool=?,
-    ~name:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Float(float)
-      ]
-        =?,
+    ~name: [@mel.unwrap] [ | `Str(string) | `Int(int) | `Float(float)]=?,
     ~onClick: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseDown:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseDown: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
+    ~onMouseEnter: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                     =?,
     ~onMouseLeave: (. Js.t({..}), React.Event.Mouse.t) => unit=?,
-    ~onMouseMove:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseOut:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseOver:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseMove: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
+    ~onMouseOut: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseOver: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
     ~onMouseUp: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~orientation:
-      [
-        | `bottom
-        | `top
-      ]
-        =?,
+    ~orientation: [ | `bottom | `top]=?,
     ~padding: paddingHorizontal=?,
     ~range: array(int)=?,
     ~reversed: bool=?,
     ~scale: scale=?,
     ~stroke: string=?,
     ~style: ReactDOM.Style.t=?,
-    ~tick:
-      [@mel.unwrap] [
-        | `Obj(Js.t({..}))
-        | `Element(React.element)
-        | `Bool(bool)
-        | `Fn('tick => React.element)
-      ]
-        =?,
+    ~tick: [@mel.unwrap] [
+             | `Obj(Js.t({..}))
+             | `Element(React.element)
+             | `Bool(bool)
+             | `Fn('tick => React.element)
+           ]
+             =?,
     ~tickCount: int=?,
     ~tickFormatter: (. 'tick, int) => string=?,
-    ~tickLine:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~tickLine: [@mel.unwrap] [ | `Bool(bool) | `Obj(Js.t({..}))]=?,
     ~tickMargin: int=?,
     ~ticks: array('ticks)=?,
-    ~tickSize:
-      [@mel.unwrap] [
-        | `Float(float)
-        | `Int(int)
-      ]
-        =?,
+    ~tickSize: [@mel.unwrap] [ | `Float(float) | `Int(int)]=?,
     ~transform: string=?,
     ~unit: string=?,
     ~width: int=?,

--- a/src/YAxis.re
+++ b/src/YAxis.re
@@ -8,91 +8,61 @@ external make:
     ~allowDataOverflow: bool=?,
     ~allowDecimals: bool=?,
     ~allowDuplicatedCategory: bool=?,
-    ~axisLine:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~axisLine: [@mel.unwrap] [ | `Bool(bool) | `Obj(Js.t({..}))]=?,
     ~className: string=?,
-    ~dataKey:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Fn('dataObj => 'data)
-      ]
-        =?,
+    ~dataKey: [@mel.unwrap] [
+                | `Str(string)
+                | `Int(int)
+                | `Fn('dataObj => 'data)
+              ]
+                =?,
     ~domain: array('domain)=?,
     ~height: int=?,
     ~hide: bool=?,
     ~interval: AxisInterval.t=?,
-    ~label:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Float(float)
-        | `Element(React.element)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~label: [@mel.unwrap] [
+              | `Str(string)
+              | `Int(int)
+              | `Float(float)
+              | `Element(React.element)
+              | `Obj(Js.t({..}))
+            ]
+              =?,
     ~minTickGap: int=?,
     ~mirror: bool=?,
-    ~name:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Float(float)
-      ]
-        =?,
+    ~name: [@mel.unwrap] [ | `Str(string) | `Int(int) | `Float(float)]=?,
     ~onClick: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseDown:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseDown: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
+    ~onMouseEnter: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                     =?,
     ~onMouseLeave: (. Js.t({..}), React.Event.Mouse.t) => unit=?,
-    ~onMouseMove:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseOut:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseOver:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseMove: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
+    ~onMouseOut: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseOver: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
     ~onMouseUp: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~orientation:
-      [
-        | `left
-        | `right
-      ]
-        =?,
+    ~orientation: [ | `left | `right]=?,
     ~padding: paddingVertical=?,
     ~range: array(int)=?,
     ~reversed: bool=?,
     ~scale: scale=?,
     ~stroke: string=?,
     ~style: ReactDOM.Style.t=?,
-    ~tick:
-      [@mel.unwrap] [
-        | `Obj(Js.t({..}))
-        | `Element(React.element)
-        | `Bool(bool)
-        | `Fn('tick => React.element)
-      ]
-        =?,
+    ~tick: [@mel.unwrap] [
+             | `Obj(Js.t({..}))
+             | `Element(React.element)
+             | `Bool(bool)
+             | `Fn('tick => React.element)
+           ]
+             =?,
     ~tickCount: int=?,
     ~tickFormatter: (. 'tick, int) => string=?,
-    ~tickLine:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~tickLine: [@mel.unwrap] [ | `Bool(bool) | `Obj(Js.t({..}))]=?,
     ~tickMargin: int=?,
     ~ticks: array('ticks)=?,
-    ~tickSize:
-      [@mel.unwrap] [
-        | `Float(float)
-        | `Int(int)
-      ]
-        =?,
+    ~tickSize: [@mel.unwrap] [ | `Float(float) | `Int(int)]=?,
     ~transform: string=?,
     ~unit: string=?,
     ~width: int=?,

--- a/src/ZAxis.re
+++ b/src/ZAxis.re
@@ -8,91 +8,61 @@ external make:
     ~allowDataOverflow: bool=?,
     ~allowDecimals: bool=?,
     ~allowDuplicatedCategory: bool=?,
-    ~axisLine:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~axisLine: [@mel.unwrap] [ | `Bool(bool) | `Obj(Js.t({..}))]=?,
     ~className: string=?,
-    ~dataKey:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Fn('dataObj => 'tick)
-      ]
-        =?,
+    ~dataKey: [@mel.unwrap] [
+                | `Str(string)
+                | `Int(int)
+                | `Fn('dataObj => 'tick)
+              ]
+                =?,
     ~domain: array('domain)=?,
     ~height: int=?,
     ~hide: bool=?,
     ~interval: AxisInterval.t=?,
-    ~label:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Float(float)
-        | `Element(React.element)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~label: [@mel.unwrap] [
+              | `Str(string)
+              | `Int(int)
+              | `Float(float)
+              | `Element(React.element)
+              | `Obj(Js.t({..}))
+            ]
+              =?,
     ~minTickGap: int=?,
     ~mirror: bool=?,
-    ~name:
-      [@mel.unwrap] [
-        | `Str(string)
-        | `Int(int)
-        | `Float(float)
-      ]
-        =?,
+    ~name: [@mel.unwrap] [ | `Str(string) | `Int(int) | `Float(float)]=?,
     ~onClick: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseDown:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseEnter:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseDown: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
+    ~onMouseEnter: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                     =?,
     ~onMouseLeave: (. Js.t({..}), React.Event.Mouse.t) => unit=?,
-    ~onMouseMove:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseOut:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~onMouseOver:
-      (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseMove: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
+    ~onMouseOut: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
+    ~onMouseOver: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit
+                    =?,
     ~onMouseUp: (. Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
-    ~orientation:
-      [
-        | `left
-        | `right
-      ]
-        =?,
+    ~orientation: [ | `left | `right]=?,
     ~padding: paddingVertical=?,
     ~range: array(int)=?,
     ~reversed: bool=?,
     ~scale: scale=?,
     ~stroke: string=?,
     ~style: ReactDOM.Style.t=?,
-    ~tick:
-      [@mel.unwrap] [
-        | `Obj(Js.t({..}))
-        | `Element(React.element)
-        | `Bool(bool)
-        | `Fn('tick => React.element)
-      ]
-        =?,
+    ~tick: [@mel.unwrap] [
+             | `Obj(Js.t({..}))
+             | `Element(React.element)
+             | `Bool(bool)
+             | `Fn('tick => React.element)
+           ]
+             =?,
     ~tickCount: int=?,
     ~tickFormatter: (. 'tick, int) => string=?,
-    ~tickLine:
-      [@mel.unwrap] [
-        | `Bool(bool)
-        | `Obj(Js.t({..}))
-      ]
-        =?,
+    ~tickLine: [@mel.unwrap] [ | `Bool(bool) | `Obj(Js.t({..}))]=?,
     ~tickMargin: int=?,
     ~ticks: array('ticks)=?,
-    ~tickSize:
-      [@mel.unwrap] [
-        | `Float(float)
-        | `Int(int)
-      ]
-        =?,
+    ~tickSize: [@mel.unwrap] [ | `Float(float) | `Int(int)]=?,
     ~transform: string=?,
     ~unit: string=?,
     ~width: int=?,

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,3 @@
  (libraries reason-react)
  (preprocess
   (pps melange.ppx reason-react-ppx)))
-


### PR DESCRIPTION
This PR changes `Tooltip.cursor` such that it accepts a `Obj(Js.t({..}))` instead of a closed object.

Also ran `make fmt`.