### PR TITLE
add syncMethod prop to charts

### DIFF
--- a/src/AreaChart.re
+++ b/src/AreaChart.re
@@ -19,6 +19,7 @@ external make:
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~stackOffset: stackOffset=?,
     ~syncId: string=?,
+    ~syncMethod: syncMethod=?,
     ~width: int=?,
     ~children: React.element
   ) =>

--- a/src/BarChart.re
+++ b/src/BarChart.re
@@ -23,6 +23,7 @@ external make:
     ~reverseStackOrder: bool=?,
     ~stackOffset: stackOffset=?,
     ~syncId: string=?,
+    ~syncMethod: syncMethod=?,
     ~width: int=?,
     ~children: React.element
   ) =>

--- a/src/ComposedChart.re
+++ b/src/ComposedChart.re
@@ -22,6 +22,7 @@ external make:
     ~reverseStackOrder: bool=?,
     ~stackOffset: stackOffset=?,
     ~syncId: string=?,
+    ~syncMethod: syncMethod=?,
     ~width: int=?,
     ~children: React.element
   ) =>

--- a/src/LineChart.re
+++ b/src/LineChart.re
@@ -17,6 +17,7 @@ external make:
     ~onMouseLeave: (Js.t({..}), React.Event.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~syncId: string=?,
+    ~syncMethod: syncMethod=?,
     ~width: int=?,
     ~children: React.element
   ) =>

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -50,6 +50,8 @@ type layout = [ | `horizontal | `vertical];
 
 type stackOffset = [ | `expand | `none | `wiggle | `silhouette | `sign];
 
+type syncMethod = [ | `index | `value];
+
 type margin = {
   .
   "top": int,


### PR DESCRIPTION
this pr adds the syncMethod `index` or `value`. The default one is `index` but if two charts have different data points they will have issues syncing their tooltips that is why `value` prop is useful so the charts can sync by checking their value(usually date) in a time series. Anyway, this prop is missing from recharts upstream