### PR TITLE
Reference line stroke width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+- add `strokeWidth` prop to `ReferenceLine`
+
 ## 5.1.0
 
 - add `SanKey` binding

--- a/src/ReferenceLine.re
+++ b/src/ReferenceLine.re
@@ -18,6 +18,7 @@ external make:
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), React.Event.Mouse.t) => unit=?,
     ~r: int=?,
     ~stroke: string=?,
+    ~strokeWidth: int=?,
     ~strokeDasharray: string=?,
     ~x: string=?,
     ~xAxis: Js.t({..})=?,


### PR DESCRIPTION
This PR adds `strokeWidth` prop to `ReferenceLine` component